### PR TITLE
add conga installation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,8 @@ Imports:
     cFIT,
     tidyr,
     methods,
-    RIRA
+    RIRA, 
+    readr
 Suggests:
     devtools,
     testthat (>= 2.1.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,8 +21,7 @@ Imports:
     cFIT,
     tidyr,
     methods,
-    RIRA, 
-    readr
+    RIRA
 Suggests:
     devtools,
     testthat (>= 2.1.0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ADD . /RDiscvr
 
 ENV RETICULATE_PYTHON=/usr/bin/python3
 
+RUN pip3 install scanpy[leiden]
+RUN git clone -b rhesus https://github.com/phbradley/conga.git && cd conga/tcrdist_cpp && make && cd .. && pip3 install -e .
+
 # NOTE: ggplot2 added to force version 3.4.0, which is needed by ggtree. Otherwise this container is pegged to ./focal/2022-10-28
 RUN echo "local({r <- getOption('repos') ;r['CRAN'] = 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest';options(repos = r);rm(r)})" >> ~/.Rprofile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,13 @@ ADD . /RDiscvr
 ENV RETICULATE_PYTHON=/usr/bin/python3
 
 RUN pip3 install scanpy[leiden]
-RUN git clone -b rhesus https://github.com/phbradley/conga.git && cd conga/tcrdist_cpp && make && cd .. && pip3 install -e .
+RUN git clone -b rhesus https://github.com/phbradley/conga.git \
+  && cd conga/tcrdist_cpp \
+  && make && cd .. \
+  && pip3 install -e . \
+  && cd /  \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # NOTE: ggplot2 added to force version 3.4.0, which is needed by ggtree. Otherwise this container is pegged to ./focal/2022-10-28
 RUN echo "local({r <- getOption('repos') ;r['CRAN'] = 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest';options(repos = r);rm(r)})" >> ~/.Rprofile
@@ -17,7 +23,7 @@ RUN --mount=type=secret,id=GITHUB_PAT \
     && echo "GH: $GITHUB_PAT" \
 	&& R CMD build . \
 	# NOTE: Matrix install has been added to force 1.5.3. Can be removed after main repos updated. \
-    && Rscript -e "install.packages('Matrix', repos = 'https://packagemanager.posit.co/cran/__linux__/focal/latest', update = TRUE, ask = FALSE)" \
+  && Rscript -e "install.packages('Matrix', repos = 'https://packagemanager.posit.co/cran/__linux__/focal/latest', update = TRUE, ask = FALSE)" \
 	&& Rscript -e "BiocManager::install(ask = F, upgrade = 'always');" \
 	&& Rscript -e "devtools::install_deps(pkg = '.', dependencies = TRUE, upgrade = 'always');" \
 	&& R CMD INSTALL --build *.tar.gz \


### PR DESCRIPTION
Hi all, 

Adding conga to the Dockerfile so that @gboggy2 can spin up the wrapper in reticulate. This installs fine without a personal access token, but will need to be fixed once the rhesus branch is deleted. 
